### PR TITLE
allow limitus rule mode configuration for bucket

### DIFF
--- a/lib/bucket.js
+++ b/lib/bucket.js
@@ -8,6 +8,7 @@ const assign = require('lodash.assign');
 const schema = Joi.object().keys({
     name: Joi.string().required(),
     interval: Joi.number().integer().required(),
+    mode: Joi.string().optional(),
     max: Joi.number().integer().required(),
     id: Joi.func().required(),
     codes: Joi.array().items(Joi.string().regex(/^[0-9x]{3}$/)).required(),
@@ -46,7 +47,7 @@ module.exports = class Bucket {
         limitus.rule(options.name, {
             max: options.max,
             interval: options.interval,
-            mode: 'interval'
+            mode: options.mode || 'interval'
         });
     }
 

--- a/lib/yaral.js
+++ b/lib/yaral.js
@@ -168,7 +168,7 @@ exports.register = function (server, options, next) {
             }
 
             // count and bucket are only available for limitus mode 'interval', not for 'continuous'
-            if (data && data.hasOwnProperty(count) && data.hasOwnProperty(bucket)) {
+            if (data && data.hasOwnProperty('count') && data.hasOwnProperty('bucket')) {
               headers['X-RateLimit-Remaining'] = Math.max(opts.bucket.max() - data.count, 0);
               headers['X-RateLimit-Reset'] = data.bucket;
             }

--- a/lib/yaral.js
+++ b/lib/yaral.js
@@ -163,11 +163,17 @@ exports.register = function (server, options, next) {
                 return reply.continue();
             }
 
-            addHeaders(res, {
-                'X-Rate-Limit': opts.bucket.max(),
-                'X-RateLimit-Remaining': Math.max(opts.bucket.max() - data.count, 0),
-                'X-RateLimit-Reset': data.bucket
-            });
+            var headers = {
+              'X-Rate-Limit': opts.bucket.max()
+            }
+
+            // count and bucket are only available for limitus mode 'interval', not for 'continuous'
+            if (data && data.hasOwnProperty(count) && data.hasOwnProperty(bucket)) {
+              headers['X-RateLimit-Remaining'] = Math.max(opts.bucket.max() - data.count, 0);
+              headers['X-RateLimit-Reset'] = data.bucket;
+            }
+
+            addHeaders(res, headers);
 
             reply.continue();
         });

--- a/readme.md
+++ b/readme.md
@@ -16,9 +16,10 @@ Yaral is Yet Another RAte Limit plugin for Hapi. But, unlike others, it does sev
 ### Configuration
 
 The following options are available when you register Yaral:
- - `buckets` is an array of interval config for [Limitus](https://github.com/MCProHosting/limitus#limitusrulename-rule) intervals. Each item should have:
+ - `buckets` is an array of interval/mode config for [Limitus](https://github.com/MCProHosting/limitus#limitusrulename-rule) intervals. Each item should have:
     - An identifying `name`
     - An `interval` that allows a `max` number of requests.
+    - A `mode` as described in the Limitus documentation. Either `interval` oder `continuous`. Defaults to `interval`.
     - An `id` function that takes a Hapi request object and returns a string, number or object that identifies the requester.
     - A list of `codes` that specify response codes that count towards this bucket's limit. Responses not in this range will not be limited. Defaults to `['2xx', '3xx']`. *Tip:* to limit all responses, use `['xxx']`.
  - `default` is a bucket `name` or array of names of the bucket applied to all routes. Defaults to `[]`. Buckets are matched first to last.


### PR DESCRIPTION
This exposes the Limitus rule `mode`, so it can be set to continuous.
Config defaults to `interval` to preserve backwards compatibility.